### PR TITLE
Correct broken link in subcompositor chapter

### DIFF
--- a/src/wayland/p_core/compositor.md
+++ b/src/wayland/p_core/compositor.md
@@ -12,15 +12,15 @@ The `wl_surface` represents an abstract canvas on which the client can display c
 object by itself does nothing: it must first be assigned some content and a role to be displayed.
 
 The content of a surface is assigned by sending a `wl_surface::attach` request, attaching a
-`wl_buffer` to the surface (we'll learn how to create them in [next chapter](./wayland/p_core/shm.html)).
+`wl_buffer` to the surface (we'll learn how to create them in [next chapter](./shm.html)).
 The buffer defines both the size and the pixel content of the surface. As such, a surface can be
 resized simply by attaching a new buffer of a different size to it.
 
 The role of a surface represents what it's used for. The core protocol includes 3 of them:
 
-- Content of a window (see [The Shell](./wayland/p_core/shell.html) for details)
-- Image of the pointer (see [The Seats](./wayland/p_core/seat.html) for details)
-- Child surface of another surface (see [The Subcompositor](./wayland/p_core/subcompositor.html) for
+- Content of a window (see [The Shell](./shell.html) for details)
+- Image of the pointer (see [The Seats](./seat.html) for details)
+- Child surface of another surface (see [The Subcompositor](./subcompositor.html) for
   details)
 
 But others can be introduced by other protocol extensions (for example background image,

--- a/src/wayland/p_core/seat.md
+++ b/src/wayland/p_core/seat.md
@@ -58,4 +58,4 @@ keyboard to the computer, but the compositor could decide to merge the two keybo
 logical keyboard, as most computers do today. In any case, the compositor gets to decide what a
 "logical seat" is.
 
-[^2]: This is the exact function of the [wayland-kbd](https:/crates.io/crates/wayland-kbd) crate.
+[^2]: This is the exact function of the [wayland-kbd](https://crates.io/crates/wayland-kbd) crate.

--- a/src/wayland/p_core/subcompositor.md
+++ b/src/wayland/p_core/subcompositor.md
@@ -25,7 +25,7 @@ know if the pointer is on the decorations or the main surface (see [next chapter
 about pointer input). But in general subsurfaces should not be used for general UI composing: this
 is expected to be done client-side by the GUI library.
 
-[next chapter]: ./wayland/p_core/seat.html
+[next chapter]: ./seat.html
 
 &nbsp;
 

--- a/src/wayland/structure.md
+++ b/src/wayland/structure.md
@@ -59,7 +59,7 @@ In the end, this kind of hierachy can be expected:
 ## Protocol extensions
 
 The set of objects and the list of their requests and events is defined in
-[an XML file](https://cgit.freedesktop.org/wayland/wayland/tree/protocol/wayland.xml). This approach allows wayland protocol extensions to be defined easily.
+[an XML file][wayland spec]. This approach allows wayland protocol extensions to be defined easily.
 
 A **protocol extension** is just another XML file, which defines another set of objects, some of
 them being globals, and thus serving as the entry points for the protocol extension.
@@ -71,6 +71,8 @@ compositor does not support the extension and the client can act accordingly (fa
 only the core protocol, or erroring out if the extension is crucial to the program).
 
 A compositor cannot force the clients to support an extension.
+
+[wayland spec]: https://cgit.freedesktop.org/wayland/wayland/tree/protocol/wayland.xml
 
 ## API versioning
 

--- a/src/wayland/structure.md
+++ b/src/wayland/structure.md
@@ -54,12 +54,12 @@ In the end, this kind of hierachy can be expected:
 
 *(The details of what these objects are and do will come later, in the [core protocol][] section.)*
 
-[core protocol]: ./wayland/p_core.html
+[core protocol]: ./p_core.html
 
 ## Protocol extensions
 
 The set of objects and the list of their requests and events is defined in
-[an XML file][wayland spec]. This approach allows wayland protocol extensions to be defined easily.
+[an XML file](https://cgit.freedesktop.org/wayland/wayland/tree/protocol/wayland.xml). This approach allows wayland protocol extensions to be defined easily.
 
 A **protocol extension** is just another XML file, which defines another set of objects, some of
 them being globals, and thus serving as the entry points for the protocol extension.
@@ -71,8 +71,6 @@ compositor does not support the extension and the client can act accordingly (fa
 only the core protocol, or erroring out if the extension is crucial to the program).
 
 A compositor cannot force the clients to support an extension.
-
-[wayland spec]: https://cgit.freedesktop.org/wayland/wayland/tree/protocol/wayland.xml
 
 ## API versioning
 


### PR DESCRIPTION
If the link is relative, no need to put the whole hierachy in the link.