### PR TITLE
Fix endianess in the example

### DIFF
--- a/src/client/sctk/drawing.md
+++ b/src/client/sctk/drawing.md
@@ -81,8 +81,9 @@ if let Some(pool) = double_pool.pool() {
     // Finally do the actual drawing. We use a BufWriter to increase performance
     {
         let mut writer = BufWriter::new(&mut *pool);
+        let pixel: u32 = 0xFF_D0_00_00;
         for _ in 0..pxcount {
-            writer.write_all(&[0xFF, 0xD0, 0x00, 0x00]).unwrap();
+            writer.write_all(&pixel.to_ne_bytes()).unwrap();
         }
         writer.flush().unwrap();
     }


### PR DESCRIPTION
The drawing example hardcoded some bytes for the pixel content. However,
other examples show that this must be in native endian. Thus, this
commit changes the example to use native endian instead.

Signed-off-by: Uli Schlachter <psychon@znc.in>