### PR TITLE
Basic readme and ci setup for compiling chapter code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: github pages
+
+on:
+  push:
+    pull_request:
+
+jobs:
+  ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: ['stable', 'beta']
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Cargo cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo
+          key: cargo-${{ matrix.rust }}
+
+      - name: Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Install system dependencies
+        run: sudo apt-get install libxkbcommon-dev libwayland-dev
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Cargo fmt
+        run: cargo fmt --all -- --check
+
+      - name: Install system dependencies
+        run: sudo apt-get install libxkbcommon-dev libwayland-dev
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+  book:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: '0.4.15'
+
+      - name: Build book
+        run: mdbook build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,10 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.4.0'
+          mdbook-version: '0.4.15'
 
-      - run: mdbook build
+      - name: Build book
+        run: mdbook build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 book/
+target/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "smithay-book"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+# Wayland crates
+wayland-backend = "0.1.0-alpha5"
+wayland-client = "0.30.0-alpha5"
+wayland-server = "0.30.0-alpha5"
+
+smithay-client-toolkit = { git = "https://github.com/Smithay/client-toolkit", branch = "rework-wayland-rs-0.30" }
+
+# TODO: 0.30 smithay should be used here when ready.
+
+calloop = "0.9.3"
+
+# Other dependencies as needed.
+
+# Here we create bin targets so each chapter's code may be tested.
+#
+# New entries should be categorized into sections just like the SUMMARY.md in the book.
+
+[[bin]]
+name = "test"
+path = "./src/test.rs"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
-# book
-Wayland &amp; Smithay book
+# The Wayland-rs &amp; Smithay book
+
+Wayland &amp; Smithay book is an introductory book to using the [Wayland] display server protocol in the Rust programming language. This book is a guide for understanding the Wayland protocol and interfacing with the Wayland protocol using the [wayland-rs], [smithay-client-toolkit] and [smithay] crates.
+
+You can read the book online [here](https://smithay.github.io/book/).
+
+## Building the book
+
+The wayland-rs &amp; Smithay book is built using [mdBook].
+
+mdBook can be installed using cargo with the following:
+
+```
+$ cargo install mdbook
+```
+
+To build the book, run the following:
+
+```
+$ mdbook build
+```
+
+The output will be in the `book` subdirectory. The book can then be previewed in your web browser by opening the `index.html` file in the book subdirectory.
+
+The book is also tested to ensure the source code in the book is correct. The following can be used to test if the source code referenced in the book compiles.
+
+```
+$ cargo check
+```
+
+[Rust]: https://www.rust-lang.org/
+[Wayland]: https://wayland.freedesktop.org/
+[mdBook]: https://github.com/rust-lang/mdBook
+
+[wayland-rs]: https://github.com/Smithay/wayland-rs
+[smithay-client-toolkit]: https://github.com/Smithay/client-toolkit
+[smithay]: https://github.com/Smithay/smithay

--- a/book.toml
+++ b/book.toml
@@ -2,3 +2,6 @@
 title = "The Smithay Handbook"
 author = "Victor \"Levans\" Berger"
 description = ""
+
+[output.html]
+git-repository-url = "https://github.com/Smithay/book"

--- a/lib.rs
+++ b/lib.rs
@@ -1,0 +1,2 @@
+// This file is intentionally empty.
+// All the source code for chapters are located in the `src` subdirectory.

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,9 +1,9 @@
 # Summary
 
 [Introduction](./intro.md)
-
+- [Test](./test.md) <!-- Remove this when possible -->
 - [Wayland apps](./client/intro.md)
-  - [General principles](./client/general/intro.md)
+<!--  - [General principles](./client/general/intro.md)
     - [Objects](./client/general/objects.md)
     - [Event queues and filters](./client/general/event_queues.md)
     - [Initializing an app](./client/general/initializing.md)
@@ -21,4 +21,5 @@
   - [Multiple outputs and HiDPI]()
   - [Cliboard and Drag'n'Drop]()
   - [Drawing with OpenGL]()
+-->
 - [Wayland Compositors](./server/intro.md)

--- a/src/test.md
+++ b/src/test.md
@@ -1,0 +1,5 @@
+As a test to ensure this CI code works, let's just try to connect to a wayland compositor.
+
+```rust,no_run
+{{#rustdoc_include test.rs:connect_to_server}}
+```

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,11 @@
+// ANCHOR: all
+
+use wayland_client::Connection;
+
+fn main() {
+    // ANCHOR: connect_to_server
+    let _connection = Connection::connect_to_env().unwrap();
+    // ANCHOR_END: connect_to_server
+}
+
+// ANCHOR_END: all


### PR DESCRIPTION
The first commit of the book for the 0.30 cycle!

This is commit is preparation for the new book (since we will effectively nuke the old book) to be written.

What does this commit introduce?
- CI infrastructure to test if the book actually builds (since it can)
- Allow chapters to have their code compile checked.
  - We can do this since mdbook allows us to use code snippets from other files using `{{#rustdoc_include <FILE>:<ANCHOR>}}` templates inside code blocks.
- Also added a simple readme. `book` isn't all that descriptive. 